### PR TITLE
Feature/dtb 625

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-10.5.2-frubana
+10.6.0-frubana

--- a/worker.conf
+++ b/worker.conf
@@ -29,8 +29,8 @@ stderr_logfile_maxbytes=0
 [eventlistener:worker_healthcheck]
 serverurl=AUTO
 command=./manage.py rq healthcheck
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/null
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/dev/null
 stderr_logfile_maxbytes=0
 events=TICK_60


### PR DESCRIPTION
En el proceso worker_healthcheck se envian las salidas de stdout_logfile y stderr_logfile a /dev/null, ya que el paquete 'supervisor_checks' logea todo lo que es "DEBUG" en stderr_logfile, provocando que en los LOGS del contenedor esten mezlados los logs del healthchek y de Redash, haciendo no usable los logs de Redash.
